### PR TITLE
Add polling support for situations where fsnotify isn't sufficient

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Here is a sample config file with the default settings:
     no_rebuild_ext:    .tpl, .tmpl, .html
     ignored:           assets, tmp
     build_delay:       600
+    poll_duration:
     colors:            1
     log_color_main:    cyan
     log_color_build:   yellow

--- a/runner.conf.sample
+++ b/runner.conf.sample
@@ -6,6 +6,7 @@ valid_ext:         .go, .tpl, .tmpl, .html
 no_rebuild_ext:    .tpl, .tmpl, .html
 ignored:           assets, tmp
 build_delay:       600
+poll_duration:
 colors:            1
 log_color_main:    cyan
 log_color_build:   yellow

--- a/runner/settings.go
+++ b/runner/settings.go
@@ -27,6 +27,7 @@ var settings = map[string]string{
 	"no_rebuild_ext":    ".tpl, .tmpl, .html",
 	"ignored":           "assets, tmp",
 	"build_delay":       "600",
+	"poll_duration":     "",
 	"colors":            "1",
 	"log_color_main":    "cyan",
 	"log_color_build":   "yellow",
@@ -143,4 +144,12 @@ func buildDelay() time.Duration {
 	value, _ := strconv.Atoi(settings["build_delay"])
 
 	return time.Duration(value)
+}
+
+func pollDuration() (bool, time.Duration) {
+	if settings["poll_duration"] != "" {
+		value, _ := time.ParseDuration(settings["poll_duration"])
+		return true, value
+	}
+	return false, 0
 }

--- a/runner/watcher.go
+++ b/runner/watcher.go
@@ -4,41 +4,82 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
-	"github.com/howeyc/fsnotify"
+	"github.com/fsnotify/fsnotify"
+	"github.com/radovskyb/watcher"
 )
 
-func watchFolder(path string) {
+type Watcher interface {
+	Add(path string) error
+}
+
+func fsWatcher() Watcher {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		fatal(err)
 	}
+	go func() {
+		for {
+			select {
+			case ev := <-watcher.Events:
+				if isWatchedFile(ev.Name) {
+					watcherLog("sending event %s", ev)
+					startChannel <- ev.String()
+				}
+			case err := <-watcher.Errors:
+				watcherLog("error: %s", err)
+			case <-stopChannel:
+				watcher.Close()
+				return
+			}
+		}
+	}()
+	return watcher
+}
 
+func pollWatcher(d time.Duration) Watcher {
+	watcher := watcher.New()
 	go func() {
 		for {
 			select {
 			case ev := <-watcher.Event:
-				if isWatchedFile(ev.Name) {
+				if isWatchedFile(ev.Path) {
 					watcherLog("sending event %s", ev)
 					startChannel <- ev.String()
 				}
 			case err := <-watcher.Error:
 				watcherLog("error: %s", err)
+			case <-stopChannel:
+				watcher.Close()
+			case <-watcher.Closed:
+				return
 			}
 		}
 	}()
 
-	watcherLog("Watching %s", path)
-	err = watcher.Watch(path)
-
-	if err != nil {
-		fatal(err)
-	}
+	go func() {
+		if err := watcher.Start(d); err != nil {
+			fatal(err)
+		}
+	}()
+	watcher.Wait()
+	return watcher
 }
 
 func watch() {
+	var watcher Watcher
+
+	poll, duration := pollDuration()
+	if poll {
+		watcherLog("polling for changes, duration: %s", duration)
+		watcher = pollWatcher(duration)
+	} else {
+		watcher = fsWatcher()
+	}
+
 	root := root()
-	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() && !isTmpDir(path) {
 			if len(path) > 1 && strings.HasPrefix(filepath.Base(path), ".") {
 				return filepath.SkipDir
@@ -49,9 +90,16 @@ func watch() {
 				return filepath.SkipDir
 			}
 
-			watchFolder(path)
+			watcherLog("Watching %s", path)
+			if err := watcher.Add(path); err != nil {
+				return err
+			}
 		}
 
 		return err
 	})
+
+	if err != nil {
+		fatal(err)
+	}
 }


### PR DESCRIPTION
Also upgrades [github.com/howeyc/fsnotify](https://github.com/howeyc/fsnotify) to the replacement [github.com/fsnotify/fsnotify](https://github.com/fsnotify/fsnotify).

fsnotify is considering adding polling support as discussed [here](https://github.com/fsnotify/fsnotify/issues/9).  [github.com/radovskyb/watcher](https://github.com/radovskyb/watcher) is mentioned in that thread.

Our specific use case is running fresh via docker, in windows, where the filesystem events aren't propagated due to volumes being mounted with SMB. That issue is discussed [here](https://github.com/docker/for-win/issues/56).