### PR TITLE
Set default path for config file.

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,12 +15,13 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/pilu/fresh/runner"
 	"os"
+
+	"github.com/pilu/fresh/runner"
 )
 
 func main() {
-	configPath := flag.String("c", "", "config file path")
+	configPath := flag.String("c", "fresh.conf", "config file path")
 	flag.Parse()
 
 	if *configPath != "" {


### PR DESCRIPTION
This allows running the `fresh` command in a directory with a "fresh.conf" file without having to do `fresh -c fresh.conf`.  Reduces a bit of typing.