### PR TITLE
optimize by swapping Walk for WalkDir

### DIFF
--- a/runner/watcher.go
+++ b/runner/watcher.go
@@ -38,8 +38,8 @@ func watchFolder(path string) {
 
 func watch() {
 	root := root()
-	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() && !isTmpDir(path) {
+	filepath.WalkDir(root, func(path string, info os.FileInfo, err error) error {
+		if !isTmpDir(path) {
 			if len(path) > 1 && strings.HasPrefix(filepath.Base(path), ".") {
 				return filepath.SkipDir
 			}


### PR DESCRIPTION
Go 1.16 added filepath.WalkDir alongside filepath.Walk for performance reasons (see https://github.com/golang/go/issues/42027). 
The WalkDir method skips files and is Walk is more efficient than Walk by avoiding to call os.Lstat on every visited file or directory.

